### PR TITLE
Enable audio-only calls

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -90,7 +90,7 @@
         <source-file src="src/android/TwilioVideoUtils.java" target-dir="src/org/apache/cordova/twiliovideo" />
         <source-file src="src/android/TwilioVideoJsonConverter.java" target-dir="src/org/apache/cordova/twiliovideo" />
 
-        <framework src="com.google.android.gms:play-services-gcm:+" />
+        <framework src="com.google.android.gms:play-services-gcm:11.8.0" />
         <framework src="src/android/twiliovideo.gradle" custom="true" type="gradleReference" />
 
         <resource-file src="src/android/res/drawable/ic_call_black_24dp.xml" target="res/drawable/ic_call_black_24dp.xml" />

--- a/src/android/CallConfig.java
+++ b/src/android/CallConfig.java
@@ -14,11 +14,13 @@ public class CallConfig implements Serializable {
     private static final String SECONDARY_COLOR_PROP = "secondaryColor";
     private static final String HANG_UP_IN_APP = "hangUpInApp";
     private static final String DISABLE_BACK_BUTTON = "disableBackButton";
+    private static final String AUDIO_ONLY = "audioOnly";
 
     private String primaryColorHex;
     private String secondaryColorHex;
     private boolean hangUpInApp;
     private boolean disableBackButton;
+    private boolean audioOnly;
 
     public void parse(JSONObject config) {
         if (config == null) {
@@ -28,6 +30,7 @@ public class CallConfig implements Serializable {
         this.secondaryColorHex = config.optString(SECONDARY_COLOR_PROP, null);
         this.hangUpInApp = config.optBoolean(HANG_UP_IN_APP, false);
         this.disableBackButton = config.optBoolean(DISABLE_BACK_BUTTON, false);
+        this.audioOnly = config.optBoolean(AUDIO_ONLY, false);
     }
 
     public String getPrimaryColorHex() {
@@ -46,4 +49,7 @@ public class CallConfig implements Serializable {
         return disableBackButton;
     }
 
+    public boolean isAudioOnly() {
+        return audioOnly;
+    }
 }

--- a/src/android/TwilioVideo.java
+++ b/src/android/TwilioVideo.java
@@ -23,8 +23,11 @@ import static org.apache.cordova.twiliovideo.CallEventId.BAD_CONNECTION_REQUEST;
 public class TwilioVideo extends CordovaPlugin {
 
     public static final String TAG = "TwilioPlugin";
-    public static final String[] PERMISSIONS_REQUIRED = new String[]{
+    public static final String[] PERMISSIONS_REQUIRED_VIDEO_CALL = new String[]{
         Manifest.permission.CAMERA,
+        Manifest.permission.RECORD_AUDIO
+    };
+    public static final String[] PERMISSIONS_REQUIRED_AUDIO_CALL = new String[]{
         Manifest.permission.RECORD_AUDIO
     };
 

--- a/src/android/TwilioVideo.java
+++ b/src/android/TwilioVideo.java
@@ -55,11 +55,17 @@ public class TwilioVideo extends CordovaPlugin {
             case "getRoom":
                 this.getRoom(callbackContext);
                 break;
-            case "hasRequiredPermissions":
-                this.hasRequiredPermissions(callbackContext);
+            case "hasRequiredVideoCallPermissions":
+                this.hasRequiredVideoCallPermissions(callbackContext);
                 break;
-            case "requestPermissions":
-                this.requestRequiredPermissions();
+            case "hasRequiredAudioCallPermissions":
+                this.hasRequiredAudioCallPermissions(callbackContext);
+                break;
+            case "requestRequiredVideoCallPermissions":
+                this.requestRequiredVideoCallPermissions();
+                break;
+            case "requestRequiredAudioCallPermissions":
+                this.requestRequiredAudioCallPermissions();
                 break;
         }
         return true;
@@ -129,23 +135,48 @@ public class TwilioVideo extends CordovaPlugin {
         }
     }
 
-    private void hasRequiredPermissions(CallbackContext callbackContext) {
-        boolean hasRequiredPermissions = true;
-        for (String permission : TwilioVideo.PERMISSIONS_REQUIRED) {
-            hasRequiredPermissions = cordova.hasPermission(permission);
-            if (!hasRequiredPermissions) {
+    private void hasRequiredVideoCallPermissions(CallbackContext callbackContext) {
+        boolean hasRequiredVideoCallPermissions = true;
+        for (String permission : TwilioVideo.PERMISSIONS_REQUIRED_VIDEO_CALL) {
+            hasRequiredVideoCallPermissions = cordova.hasPermission(permission);
+            if (!hasRequiredVideoCallPermissions) {
                 break;
             }
         }
 
         callbackContext.sendPluginResult(
-            new PluginResult(PluginResult.Status.OK, hasRequiredPermissions)
+            new PluginResult(PluginResult.Status.OK, hasRequiredVideoCallPermissions)
         );
     }
 
-    private void requestRequiredPermissions() {
+    private void hasRequiredAudioCallPermissions(CallbackContext callbackContext) {
+        boolean hasRequiredAudioCallPermissions = true;
+        for (String permission : TwilioVideo.PERMISSIONS_REQUIRED_AUDIO_CALL) {
+            hasRequiredAudioCallPermissions = cordova.hasPermission(permission);
+            if (!hasRequiredAudioCallPermissions) {
+                break;
+            }
+        }
+
+        callbackContext.sendPluginResult(
+            new PluginResult(PluginResult.Status.OK, hasRequiredAudioCallPermissions)
+        );
+    }
+
+    private void requestRequiredVideoCallPermissions() {
         cordova.requestPermissions(
-            this, PERMISSIONS_REQUIRED_REQUEST_CODE, PERMISSIONS_REQUIRED);
+            this, 
+            PERMISSIONS_REQUIRED_REQUEST_CODE, 
+            PERMISSIONS_REQUIRED_VIDEO_CALL
+        );
+    }
+
+    private void requestRequiredAudioCallPermissions() {
+        cordova.requestPermissions(
+            this, 
+            PERMISSIONS_REQUIRED_REQUEST_CODE, 
+            PERMISSIONS_REQUIRED_AUDIO_CALL
+        );
     }
 
     @Override

--- a/src/android/TwilioVideoActivity.java
+++ b/src/android/TwilioVideoActivity.java
@@ -317,8 +317,11 @@ public class TwilioVideoActivity extends AppCompatActivity implements CallAction
     private void requestPermissions() {
         ActivityCompat.requestPermissions(
             this,
-            TwilioVideo.PERMISSIONS_REQUIRED,
-            PERMISSIONS_REQUEST_CODE);
+            config.isAudioOnly()
+                ? TwilioVideo.PERMISSIONS_REQUIRED_AUDIO_CALL
+                : TwilioVideo.PERMISSIONS_REQUIRED_VIDEO_CALL,
+            PERMISSIONS_REQUEST_CODE
+        );
     }
 
     private void createAudioAndVideoTracks() {
@@ -329,11 +332,13 @@ public class TwilioVideoActivity extends AppCompatActivity implements CallAction
         // Share your camera
         cameraCapturer = new CameraCapturerCompat(this,
             CameraCapturerCompat.Source.FRONT_CAMERA);
-        localVideoTrack = LocalVideoTrack.create(this,
-            true,
-            cameraCapturer,
-            LOCAL_VIDEO_TRACK_NAME);
-        this.moveLocalVideoToThumbnailView();
+        if (config.isAudioOnly() == false) {
+            localVideoTrack = LocalVideoTrack.create(this,
+                true,
+                cameraCapturer,
+                LOCAL_VIDEO_TRACK_NAME);
+            this.moveLocalVideoToThumbnailView();
+        }
     }
 
     private void connectToRoom() {
@@ -389,6 +394,11 @@ public class TwilioVideoActivity extends AppCompatActivity implements CallAction
         muteActionFab.setOnClickListener(muteClickListener());
         switchAudioActionFab.show();
         switchAudioActionFab.setOnClickListener(switchAudioClickListener());
+
+        if (config.isAudioOnly() == true) {
+            switchCameraActionFab.hide();
+            localVideoActionFab.hide();
+        }
     }
 
     private void showAudioDevices() {

--- a/src/android/TwilioVideoActivity.java
+++ b/src/android/TwilioVideoActivity.java
@@ -167,9 +167,12 @@ public class TwilioVideoActivity extends AppCompatActivity implements CallAction
         this.config = (CallConfig) intent.getSerializableExtra("config");
 
         Log.d(TwilioVideo.TAG, "BEFORE REQUEST PERMISSIONS");
-        if (!hasPermissionForCameraAndMicrophone()) {
-            Log.d(TwilioVideo.TAG, "REQUEST PERMISSIONS");
-            requestPermissions();
+        if (!config.isAudioOnly() && !hasPermissionForCameraAndMicrophone()) {
+            Log.d(TwilioVideo.TAG, "REQUEST VIDEO CALL PERMISSIONS");
+            requestRequiredVideoCallPermissions();
+        } else if (config.isAudioOnly() && !hasPermissionForMicrophone()) {
+            Log.d(TwilioVideo.TAG, "REQUEST AUDIO CALL PERMISSIONS");
+            requestRequiredVideoCallPermissions();
         } else {
             Log.d(TwilioVideo.TAG, "PERMISSIONS OK. CREATE LOCAL MEDIA");
             createAudioAndVideoTracks();
@@ -314,12 +317,24 @@ public class TwilioVideoActivity extends AppCompatActivity implements CallAction
             resultMic == PackageManager.PERMISSION_GRANTED;
     }
 
-    private void requestPermissions() {
+    private boolean hasPermissionForMicrophone() {
+        int resultMic = ContextCompat.checkSelfPermission(this,
+            Manifest.permission.RECORD_AUDIO);
+        return resultMic == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private void requestRequiredVideoCallPermissions() {
         ActivityCompat.requestPermissions(
             this,
-            config.isAudioOnly()
-                ? TwilioVideo.PERMISSIONS_REQUIRED_AUDIO_CALL
-                : TwilioVideo.PERMISSIONS_REQUIRED_VIDEO_CALL,
+            TwilioVideo.PERMISSIONS_REQUIRED_VIDEO_CALL,
+            PERMISSIONS_REQUEST_CODE
+        );
+    }
+
+    private void requestRequiredAudioCallPermissions() {
+        ActivityCompat.requestPermissions(
+            this,
+            TwilioVideo.PERMISSIONS_REQUIRED_VIDEO_CALL,
             PERMISSIONS_REQUEST_CODE
         );
     }

--- a/src/ios/TwilioVideoConfig.h
+++ b/src/ios/TwilioVideoConfig.h
@@ -5,6 +5,7 @@
 @property NSString *primaryColorHex;
 @property NSString *secondaryColorHex;
 @property BOOL hangUpInApp;
+@property BOOL audioOnly;
 
 -(void) parse:(NSDictionary*)config;
 + (UIColor *)colorFromHexString:(NSString *)hexString;

--- a/src/ios/TwilioVideoConfig.m
+++ b/src/ios/TwilioVideoConfig.m
@@ -3,6 +3,7 @@
 #define PRIMARY_COLOR_PROP                  @"primaryColor"
 #define SECONDARY_COLOR_PROP                @"secondaryColor"
 #define HANG_UP_IN_APP                      @"hangUpInApp"
+#define AUDIO_ONLY                          @"audioOnly"
 
 @implementation TwilioVideoConfig
 
@@ -12,6 +13,8 @@
     self.secondaryColorHex = [config objectForKey:SECONDARY_COLOR_PROP];
     NSNumber *hangUpInApp = [config objectForKey:HANG_UP_IN_APP];
     self.hangUpInApp = hangUpInApp ? [hangUpInApp boolValue] : false;
+    NSNumber *audioOnly = [config objectForKey:AUDIO_ONLY];
+    self.audioOnly = audioOnly ? [audioOnly boolValue] : false;
 }
 
 + (UIColor *)colorFromHexString:(NSString *)hexString {

--- a/src/ios/TwilioVideoPermissions.h
+++ b/src/ios/TwilioVideoPermissions.h
@@ -3,7 +3,9 @@
 
 @interface TwilioVideoPermissions : NSObject
 
-+ (BOOL)hasRequiredPermissions;
-+ (void)requestRequiredPermissions:(void (^)(BOOL))response;
++ (BOOL)hasRequiredVideoCallPermissions;
++ (BOOL)hasRequiredAudioCallPermissions;
++ (void)requestRequiredVideoCallPermissions:(void (^)(BOOL))response;
++ (void)requestRequiredAudioCallPermissions:(void (^)(BOOL))response;
 
 @end

--- a/src/ios/TwilioVideoPermissions.m
+++ b/src/ios/TwilioVideoPermissions.m
@@ -2,18 +2,29 @@
 
 @implementation TwilioVideoPermissions
 
-+ (BOOL)hasRequiredPermissions {
++ (BOOL)hasRequiredVideoCallPermissions {
     AVAuthorizationStatus videoPermissionStatus = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
     AVAudioSessionRecordPermission audioPermissionStatus = [AVAudioSession sharedInstance].recordPermission;
     return videoPermissionStatus == AVAuthorizationStatusAuthorized && audioPermissionStatus == AVAudioSessionRecordPermissionGranted;
 }
 
-+ (void)requestRequiredPermissions:(void (^)(BOOL))response {
++ (BOOL)hasRequiredAudioCallPermissions {
+    AVAudioSessionRecordPermission audioPermissionStatus = [AVAudioSession sharedInstance].recordPermission;
+    return audioPermissionStatus == AVAudioSessionRecordPermissionGranted;
+}
+
++ (void)requestRequiredVideoCallPermissions:(void (^)(BOOL))response {
     [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL grantedCamera)
     {
         [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL grantedAudio) {
             if (response) { response(grantedAudio && grantedCamera); }
         }];
+    }];
+}
+
++ (void)requestRequiredAudioCallPermissions:(void (^)(BOOL))response {
+    [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL grantedAudio) {
+        if (response) { response(grantedAudio); }
     }];
 }
 

--- a/src/ios/TwilioVideoPlugin.m
+++ b/src/ios/TwilioVideoPlugin.m
@@ -52,13 +52,26 @@
     [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
 }
 
-- (void)hasRequiredPermissions:(CDVInvokedUrlCommand*)command {
-    BOOL hasRequiredPermissions = [TwilioVideoPermissions hasRequiredPermissions];
-    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:hasRequiredPermissions] callbackId:command.callbackId];
+- (void)hasRequiredVideoCallPermissions:(CDVInvokedUrlCommand*)command {
+    BOOL hasRequiredVideoCallPermissions = [TwilioVideoPermissions hasRequiredVideoCallPermissions];
+    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:hasRequiredVideoCallPermissions] callbackId:command.callbackId];
 }
 
-- (void)requestPermissions:(CDVInvokedUrlCommand*)command {
-    [TwilioVideoPermissions requestRequiredPermissions:^(BOOL grantedPermissions) {
+- (void)hasRequiredAudioCallPermissions:(CDVInvokedUrlCommand*)command {
+    BOOL hasRequiredAudioCallPermissions = [TwilioVideoPermissions hasRequiredAudioCallPermissions];
+    [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:hasRequiredAudioCallPermissions] callbackId:command.callbackId];
+}
+
+- (void)requestRequiredVideoCallPermissions:(CDVInvokedUrlCommand*)command {
+    [TwilioVideoPermissions requestRequiredVideoCallPermissions:^(BOOL grantedPermissions) {
+                     [self.commandDelegate sendPluginResult:
+         [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:grantedPermissions]
+                                    callbackId:command.callbackId];
+    }];
+}
+
+- (void)requestRequiredAudioCallPermissions:(CDVInvokedUrlCommand*)command {
+    [TwilioVideoPermissions requestRequiredAudioCallPermissions:^(BOOL grantedPermissions) {
                      [self.commandDelegate sendPluginResult:
          [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:grantedPermissions]
                                     callbackId:command.callbackId];

--- a/src/ios/TwilioVideoViewController.m
+++ b/src/ios/TwilioVideoViewController.m
@@ -62,14 +62,25 @@ static TVIRoom *currentRoom;
     self.accessToken = token;
     [self showRoomUI:YES];
 
-    [TwilioVideoPermissions requestRequiredPermissions:^(BOOL grantedPermissions) {
-         if (grantedPermissions) {
-             [self doConnect];
-         } else {
-             [[TwilioVideoManager getInstance] publishEvent:[CallEvent of:EVENT_PERMISSIONS_REQUIRED]];
-             [self handleConnectionError];
-         }
-    }];
+    if ([self.config audioOnly]) {
+        [TwilioVideoPermissions requestRequiredAudioCallPermissions:^(BOOL grantedPermissions) {
+            if (grantedPermissions) {
+                [self doConnect];
+            } else {
+                [[TwilioVideoManager getInstance] publishEvent:[CallEvent of:EVENT_PERMISSIONS_REQUIRED]];
+                [self handleConnectionError];
+            }
+        }];
+    } else {
+        [TwilioVideoPermissions requestRequiredVideoCallPermissions:^(BOOL grantedPermissions) {
+            if (grantedPermissions) {
+                [self doConnect];
+            } else {
+                [[TwilioVideoManager getInstance] publishEvent:[CallEvent of:EVENT_PERMISSIONS_REQUIRED]];
+                [self handleConnectionError];
+            }
+        }];
+    }
 }
 
 - (IBAction)disconnectButtonPressed:(id)sender {
@@ -112,7 +123,7 @@ static TVIRoom *currentRoom;
 
 - (void)startPreview {
     // TVICameraCapturer is not supported with the Simulator.
-    if ([self isSimulator]) {
+    if ([self isSimulator] || [self.config audioOnly]) {
         [self.previewView removeFromSuperview];
         return;
     }

--- a/types/index.ts
+++ b/types/index.ts
@@ -28,16 +28,28 @@ export interface TwilioVideoPlugin {
   getRoom(): Promise<TwilioVideoAppRoom>;
 
   /**
-   * Check if the user granted all required permissions (Camera and Microphone)
+   * Check if the user granted all required permissions for a video call (Camera and Microphone)
    * @return If user has granted all permissions or not
    */
-  hasRequiredPermissions(): Promise<boolean>;
+  hasRequiredVideoCallPermissions(): Promise<boolean>;
 
   /**
-   * Request required permissions (Camera and Microphone)
+   * Check if the user granted all required permissions for an audio call (Microphone)
    * @return If user has granted all permissions or not
    */
-  requestPermissions(): Promise<boolean>;
+  hasRequiredAudioCallPermissions(): Promise<boolean>;
+
+  /**
+   * Request required permissions for a video call (Camera and Microphone)
+   * @return If user has granted all permissions or not
+   */
+   requestRequiredVideoCallPermissions(): Promise<boolean>;
+
+  /**
+   * Request required permissions for an audio call (Microphone)
+   * @return If user has granted all permissions or not
+   */
+   requestRequiredAudioCallPermissions(): Promise<boolean>;
 }
 
 export interface TwilioVideoAppConfig {
@@ -58,6 +70,10 @@ export interface TwilioVideoAppConfig {
    * (Only Android) (Default = false) Flag to disable back button while the videocall is running.
    */
   disableBackButton?: boolean;
+  /**
+   * (Default = false) Flag to disable video functionality in calls.
+   */
+  audioOnly?: boolean;
 }
 
 export interface TwilioVideoAppEvent {

--- a/www/twiliovideo.js
+++ b/www/twiliovideo.js
@@ -33,23 +33,43 @@ TwilioVideo.getRoom = function() {
     });
 };
 
-TwilioVideo.hasRequiredPermissions = function() {
+TwilioVideo.hasRequiredVideoCallPermissions = function() {
     return new Promise(function(resolve, reject) {
         exec(function(result) {
             resolve(result);
         }, function(error) {
             reject(error);
-        }, "TwilioVideoPlugin", "hasRequiredPermissions", []);
+        }, "TwilioVideoPlugin", "hasRequiredVideoCallPermissions", []);
     });
 };
 
-TwilioVideo.requestPermissions = function() {
+TwilioVideo.hasRequiredAudioCallPermissions = function() {
     return new Promise(function(resolve, reject) {
         exec(function(result) {
             resolve(result);
         }, function(error) {
             reject(error);
-        }, "TwilioVideoPlugin", "requestPermissions", []);
+        }, "TwilioVideoPlugin", "hasRequiredAudioCallPermissions", []);
+    });
+};
+
+TwilioVideo.requestRequiredVideoCallPermissions = function() {
+    return new Promise(function(resolve, reject) {
+        exec(function(result) {
+            resolve(result);
+        }, function(error) {
+            reject(error);
+        }, "TwilioVideoPlugin", "requestRequiredVideoCallPermissions", []);
+    });
+};
+
+TwilioVideo.requestRequiredAudioCallPermissions = function() {
+    return new Promise(function(resolve, reject) {
+        exec(function(result) {
+            resolve(result);
+        }, function(error) {
+            reject(error);
+        }, "TwilioVideoPlugin", "requestRequiredAudioCallPermissions", []);
     });
 };
 


### PR DESCRIPTION
This PR enables audio only calls and allows for separate calling of permissions required for audio/video calls.

As an aside, this also prevents conflicts with popular cordova plugin `cordova-background-geolocation-plugin`.